### PR TITLE
Create user u3 with UID 3000 to prevent UID clash with Ubuntu user ID…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER "Jozko Skrablin"
 RUN apk add --no-cache -qq libffi gcc postgresql-dev musl-dev bash libffi-dev libffi-dev libxslt-dev zlib libjpeg-turbo-dev
 
 
-RUN adduser -D u3
+RUN adduser -D -u 3000 u3
 
 RUN mkdir -p /home/u3/data/files
 


### PR DESCRIPTION
… which are >= 1000. u3 reserved UID is needed for setting UIDs on Docker hosts volumes