### PR TITLE
Proposed fix for dkum crawler exceptions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,12 @@
 FROM python:3.5-alpine
 
-
 MAINTAINER "Jozko Skrablin"
 
 RUN apk add --no-cache -qq libffi gcc postgresql-dev musl-dev bash libffi-dev libffi-dev libxslt-dev zlib libjpeg-turbo-dev
 
-
 RUN adduser -D -u 3000 u3
 
-RUN mkdir -p /home/u3/tmp
-RUN mkdir -p /home/u3/data/files
-
+RUN mkdir -p /home/u3/{tmp,data/files}
 
 ADD . /home/u3
 
@@ -19,8 +15,8 @@ RUN chown -R u3:u3 /home/u3
 ADD ./run-scrapy.sh /usr/local/bin/run-scrapy.sh
 RUN chmod +x /usr/local/bin/run-scrapy.sh
 
-RUN pip install dumb-init
-RUN pip install --upgrade -r /home/u3/requirements.txt
+RUN pip install dumb-init && \
+  pip install --upgrade -r /home/u3/requirements.txt
 
 WORKDIR /home/u3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ RUN apk add --no-cache -qq libffi gcc postgresql-dev musl-dev bash libffi-dev li
 
 RUN adduser -D -u 3000 u3
 
+RUN mkdir -p /home/u3/tmp
 RUN mkdir -p /home/u3/data/files
+
 
 ADD . /home/u3
 

--- a/feeder/extensions/stats.py
+++ b/feeder/extensions/stats.py
@@ -1,10 +1,7 @@
 from scrapy import signals
-from scrapy.exceptions import NotConfigured
 from twisted.internet.task import LoopingCall
 from feeder.settings import DOGSTATSD_ADDR, DOGSTATSD_PORT, PERSIST_STATS_INTERVAL
 from datadog import statsd, DogStatsd
-from pdb import set_trace
-from pprint import pprint
 
 
 class DatadogStats(object):

--- a/feeder/settings.py
+++ b/feeder/settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from os import getenv
+from os import getenv, path, getcwd
 from sqlalchemy.engine.url import URL
 
 # Scrapy settings for startproject project
@@ -115,6 +115,8 @@ ITEM_PIPELINES = {
 # HTTPCACHE_DIR = 'httpcache'
 # HTTPCACHE_IGNORE_HTTP_CODES = []
 # HTTPCACHE_STORAGE = 'scrapy.extensions.httpcache.FilesystemCacheStorage'
+
+TEMP_FILES_FOLDER = getenv('TEMP_FILES_FOLDER', path.join(getcwd(), "tmp/"))
 
 FILES_STORE = getenv('FILES_STORE', './data/files')
 

--- a/feeder/spiders/dkum.py
+++ b/feeder/spiders/dkum.py
@@ -4,11 +4,10 @@ import arrow
 from feeder.spiders.rul import RUL
 import math
 from scrapy.http import FormRequest
-import os
+import os, glob
+from slugify import slugify
+from feeder.settings import TEMP_FILES_FOLDER
 
-# Add the temp dir settings - DKUM spider needs it
-HOMEDIR = os.getenv('HOME')
-TMPDIR = os.path.join(HOMEDIR, 'tmp/')
 
 class DKUM(RUL):
     name = "dkum"
@@ -32,7 +31,7 @@ class DKUM(RUL):
         return [Request(response.url + "&page=%d" % page) for page in range(1, pages)]
 
     def parse_page(self, response):
-        self.clear_tmp()
+        self.clear_temp()
         urls = set([self.prepare_url(url) for url in response.css("a[href^='Dokument.php']").xpath("@href").extract()])
         return [Request(url, meta={'isConsent': True, 'cookiejar': url}) for url in urls if
                 not self.exists_by({'scraped_url': url})]
@@ -52,28 +51,32 @@ class DKUM(RUL):
             return None
 
         file_name = str(response.headers['Content-Disposition']).split(';')[1].strip().split("=")[1][:-1]
+        file_name = slugify(file_name, to_lower=True) \
+            .replace('-pdf', '.pdf', 1) \
+            .replace('-doc', '.doc', 1)
 
-        with open(os.path.join(TMPDIR, file_name), 'wb') as f:
+        temp_path = os.path.join(TEMP_FILES_FOLDER, file_name)
+
+        # Writes content to "TEMP_DIR"
+        with open(temp_path, 'wb+') as f:
             f.write(response.body)
-
-        #dir_path = os.path.dirname(os.path.realpath(__file__))
-        file_path = os.path.join(TMPDIR, file_name).replace('feeder/spiders', '', 1)
 
         return Source(
             domain=self.domain,
             scraped_at=arrow.utcnow(),
             scraped_url=url,
-            file_urls=['file://%s' % os.path.join(TMPDIR, file_name)]
+            file_urls=['file://%s' % temp_path]
         )
 
-    def clear_tmp(self):
-        # Remove items in tmp/
-        #dir_path = os.path.dirname(os.path.realpath(__file__))
-        file_path = os.path.join(TMPDIR, '*').replace('feeder/spiders', '', 1)
-        os.system('rm -rf %s' % file_path)
+    def clear_temp(self):
+        """ Removes items in TEMP_DIR """
+        file_path = os.path.join(TEMP_FILES_FOLDER, '*')
+        files = glob.glob(file_path)
+        for file_name in files:
+            os.unlink(file_name)
 
     def __del__(self):
-        self.clear_tmp()
+        self.clear_temp()
 
     def prepare_url(self, url):
         return ('' + self.base_url + '/' + url).split('&')[0]

--- a/feeder/spiders/dkum.py
+++ b/feeder/spiders/dkum.py
@@ -6,6 +6,9 @@ import math
 from scrapy.http import FormRequest
 import os
 
+# Add the temp dir settings - DKUM spider needs it
+HOMEDIR = os.getenv('HOME')
+TMPDIR = os.path.join(HOMEDIR, 'tmp/')
 
 class DKUM(RUL):
     name = "dkum"
@@ -50,23 +53,23 @@ class DKUM(RUL):
 
         file_name = str(response.headers['Content-Disposition']).split(';')[1].strip().split("=")[1][:-1]
 
-        with open('tmp/%s' % file_name, 'wb') as f:
+        with open(os.path.join(TMPDIR, file_name), 'wb') as f:
             f.write(response.body)
 
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        file_path = (dir_path + '/tmp/%s' % file_name).replace('feeder/spiders', '', 1)
+        #dir_path = os.path.dirname(os.path.realpath(__file__))
+        file_path = os.path.join(TMPDIR, file_name).replace('feeder/spiders', '', 1)
 
         return Source(
             domain=self.domain,
             scraped_at=arrow.utcnow(),
             scraped_url=url,
-            file_urls=['file://%s' % file_path]
+            file_urls=['file://%s' % os.path.join(TMPDIR, file_name)]
         )
 
     def clear_tmp(self):
         # Remove items in tmp/
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        file_path = (dir_path + '/tmp/*').replace('feeder/spiders', '', 1)
+        #dir_path = os.path.dirname(os.path.realpath(__file__))
+        file_path = os.path.join(TMPDIR, '*').replace('feeder/spiders', '', 1)
         os.system('rm -rf %s' % file_path)
 
     def __del__(self):

--- a/recreate_database.py
+++ b/recreate_database.py
@@ -4,7 +4,8 @@ from feeder.models import *
 
 drop = getenv("DROP", "False")
 
-if drop is "True":
+if "True" in drop:
+    print("Droping,..")
     Base.metadata.drop_all(db_connect())
 
 Base.metadata.create_all(db_connect())

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ SQLAlchemy
 psycopg2
 datadog
 scrapy-sentry
+awesome-slugify


### PR DESCRIPTION
 - It was unable to find the location of temp files. 
- See https://sentry.io/univizor/univizor/issues/192956029/

- [x] Files are now correctly downloaded to the temp directory
- [x] [clear_tmp()](https://github.com/univizor/u3/blob/dkum_fix/feeder/spiders/dkum.py#L69-L73) still not working
- [x] Code can be improved

